### PR TITLE
Update docuementation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,4 +10,5 @@ Usage
 
     from lintipy import Handler
 
-    handle = Handler('PEP8', 'pycodestyle', '.')
+    def handle(*args, **kwargs):
+        return Handler('PEP8', 'pycodestyle', '.')(*args, **kwargs)


### PR DESCRIPTION
AWS lambda leaks module states between invocations.
Initializing the callable on the fly bypasses this problem.